### PR TITLE
Don't jump around when reformatting in normal mode

### DIFF
--- a/plugin/revytex.vim
+++ b/plugin/revytex.vim
@@ -267,8 +267,8 @@ command! RevytexToSong              call ToSong()
 
 if !exists("g:revytex_no_mappings") || ! g:revytex_no_mappings
   vmap s <Nop>
-  nmap sq <Plug>FormatSketch()<CR>
+  nmap sq <Plug>FormatSketch<CR>
   vmap sq :call FormatSketch()<CR>
-  nmap sa <Plug>FormatSong()<CR>
+  nmap sa <Plug>FormatSong<CR>
   vmap sa :call FormatSong()<CR>
 endif


### PR DESCRIPTION
`<Plug>FormatSketch` and `<Plug>FormatSong` are key mappings, not
functions. Therefore, the `()` is interpreted not as an argument
list to the functions, but instead as the command `(` and `)`,
explaining the weird jumping behavior.

Solve the problem by removing the `()`s, fixing #1.